### PR TITLE
strict check on repackCommandString

### DIFF
--- a/library/Soliant/SimpleFM/Adapter.php
+++ b/library/Soliant/SimpleFM/Adapter.php
@@ -1041,7 +1041,7 @@ class Adapter
                 if ($value instanceof \Datetime) {
                     $value = $value->format('m/d/Y H:i:s');
                 }
-                $commandstring .= ($value === null || $value == '') ? $amp . urlencode($name) : $amp . urlencode($name) . '=' . urlencode($value);
+                $commandstring .= ($value === null || $value === '') ? $amp . urlencode($name) : $amp . urlencode($name) . '=' . urlencode($value);
                 $amp = '&';
             }
         }


### PR DESCRIPTION
Without proposed strict check, a value of 0 is evaluated as empty string. So, for example, passing ['-skip' => 0] in commands would result in a wrong parameter, since the zero is dropped.