### PR TITLE
support branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,11 @@
             "Soliant\\": "library/",
             "SoliantTest\\": "tests/"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1.x-dev"
+        }
     }
+
 }


### PR DESCRIPTION
With this option, we can require "2.1.*@dev" and getting last updates, without relying on "dev-master" (that is bad), or without waiting for a new tag.
Of course, you should adapt this value when 2.1 stable will be released