### PR TITLE
Refactor Loader to return its own errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Example:
             'myRepeatingField'    => 'Foo',
             'myRepeatingField(2)' => 'Bar',
             'myRepeatingField(3)' => 'Baz',
-            '-new'                => NULL
+            '-new'                => null
         )
     );
 ```
@@ -264,7 +264,7 @@ For instance, _by default search queries are executed as a LIKE_. If you want to
 Examples
 ```
 $commandArray = [
-    'field1' => '==value1', // exactly 'value1'
+    'field1' => '==value1', // exactly  'value1'
     'field2' => 'value2'    // contains 'value2'
 ];
 ```

--- a/documentation/simplefm_example.php
+++ b/documentation/simplefm_example.php
@@ -43,8 +43,8 @@ $adapter = new Adapter($hostConnection);
  * If you need to use one of the alternative loaders, you instantiate is with the Adapter, and then add it with
  * the Adapter::setLoader method.
  */
-// $loader = new \Soliant\SimpleFM\Loader\Curl($adapter)
-// $loader = new \Soliant\SimpleFM\Loader\FileGetContents($adapter)
+// $loader = new \Soliant\SimpleFM\Loader\Curl();
+// $loader = new \Soliant\SimpleFM\Loader\FileGetContents();
 // $adapter->setLoader($loader);
 
 /**
@@ -129,9 +129,14 @@ $url          = $result->getDebugUrl();
 $errorCode    = $result->getErrorCode();
 $errorMessage = $result->getErrorMessage();
 $errorType    = $result->getErrorType();
-$count        = $result->getCount();
-$fetchSize    = $result->getFetchSize();
-$rows         = $result->getRows();
+$count        = null;
+$fetchSize    = null;
+$rows         = [];
+if ($result instanceof FmResultSet) {
+    $count        = $result->getCount();
+    $fetchSize    = $result->getFetchSize();
+    $rows         = $result->getRows();
+}
 
 /**
  * Handle the result:

--- a/library/Soliant/SimpleFM/Adapter.php
+++ b/library/Soliant/SimpleFM/Adapter.php
@@ -227,7 +227,14 @@ class Adapter
         $xml = $this->loader->load();
 
         if ($this->uri == FmLayoutParser::GRAMMAR) {
+            if ($this->loader->hasError()) {
+                return $this->loader->getLastErrorResultFmLayout();
+            }
             return $this->parseFmpXmlLayout($xml);
+        }
+
+        if ($this->loader->hasError()) {
+            return $this->loader->getLastErrorResultFmResultSet();
         }
         return $this->parseFmResultSet($xml);
     }

--- a/library/Soliant/SimpleFM/Loader/Curl.php
+++ b/library/Soliant/SimpleFM/Loader/Curl.php
@@ -24,6 +24,7 @@ class Curl extends AbstractLoader
         $this->prepare();
         $url = $this->postUrl;
         $curlHandle = curl_init($url);
+        $curlError = [];
 
         curl_setopt($curlHandle, CURLOPT_USERPWD, $this->credentials);
         curl_setopt($curlHandle, CURLOPT_POST, true);
@@ -31,11 +32,17 @@ class Curl extends AbstractLoader
         curl_setopt($curlHandle, CURLOPT_SSL_VERIFYPEER, $this->adapter->getHostConnection()->getSslVerifyPeer());
 
         ob_start();
-            $success = curl_exec($curlHandle);
-            curl_close($curlHandle);
-            $data = trim(ob_get_contents());
+        $success = curl_exec($curlHandle);
+        if (!$success) {
+            $curlError['type'] = 'CURL';
+            $curlError['code'] = curl_errno($curlHandle);
+            $curlError['message'] = 'Curl error: ' . curl_strerror($curlError['code']);
+        }
+        curl_close($curlHandle);
+        $data = trim(ob_get_contents());
         ob_end_clean();
 
-        return $this->handleReturn($data);
+
+        return $this->handleReturn($data, $curlError);
     }
 }

--- a/library/Soliant/SimpleFM/Loader/Mock.php
+++ b/library/Soliant/SimpleFM/Loader/Mock.php
@@ -47,7 +47,6 @@ class Mock extends AbstractLoader
     {
         $this->prepare();
         $testXml = $testXmlOverride ? $testXmlOverride : $this->testXml;
-        $this->errorCapture();
         return $this->handleReturn($testXml);
     }
 }

--- a/tests/SoliantTest/SimpleFM/AdapterTest.php
+++ b/tests/SoliantTest/SimpleFM/AdapterTest.php
@@ -11,6 +11,7 @@ namespace SoliantTest\SimpleFM;
 
 use Soliant\SimpleFM\Adapter;
 use Soliant\SimpleFM\HostConnection;
+use Soliant\SimpleFM\Loader\Curl;
 use Soliant\SimpleFM\Loader\Mock as MockLoader;
 use Soliant\SimpleFM\Parser\FmLayoutParser;
 use Soliant\SimpleFM\Parser\FmResultSetParser;
@@ -259,6 +260,9 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Soliant\SimpleFM\Adapter::execute
      * @covers Soliant\SimpleFM\Adapter::parseFmResultSet
+     * @covers Soliant\SimpleFM\Loader\AbstractLoader::hasError
+     * @covers Soliant\SimpleFM\Loader\AbstractLoader::getLastErrorResult
+     * @covers Soliant\SimpleFM\Loader\AbstractLoader::getLastErrorResultFmResultSet
      */
     public function testExecuteWithParseFmResultSet()
     {
@@ -270,13 +274,20 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
 
         $this->adapterInstance->useResultSetGrammar();
         $result = $this->adapterInstance->execute();
-
         $this->assertEquals($result->getCount(), 17);
+
+        $this->adapterInstance->setLoader(new Curl());
+        $result = $this->adapterInstance->execute();
+        $this->assertEquals($result->getErrorType(), 'PHP');
+        $this->assertEquals($result->getCount(), null);
     }
 
     /**
      * @covers Soliant\SimpleFM\Adapter::execute
      * @covers Soliant\SimpleFM\Adapter::parseFmpXmlLayout
+     * @covers Soliant\SimpleFM\Loader\AbstractLoader::hasError
+     * @covers Soliant\SimpleFM\Loader\AbstractLoader::getLastErrorResult
+     * @covers Soliant\SimpleFM\Loader\AbstractLoader::getLastErrorResultFmLayout
      */
     public function testExecuteWithParseFmpXmlLayout()
     {
@@ -288,7 +299,11 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
 
         $this->adapterInstance->useLayoutGrammar();
         $result = $this->adapterInstance->execute();
-
         $this->assertEquals($result->getLayout()['name'], 'Projects | Web');
+
+        $this->adapterInstance->setLoader(new Curl());
+        $result = $this->adapterInstance->execute();
+        $this->assertEquals($result->getErrorType(), 'PHP');
+        $this->assertEquals($result->getLayout(), []);
     }
 }

--- a/tests/SoliantTest/SimpleFM/Loader/CurlTest.php
+++ b/tests/SoliantTest/SimpleFM/Loader/CurlTest.php
@@ -52,6 +52,7 @@ class CurlTest extends \PHPUnit_Framework_TestCase
      * @covers Soliant\SimpleFM\Loader\AbstractLoader::handleReturn
      * @covers Soliant\SimpleFM\Loader\AbstractLoader::errorCapture
      * @covers Soliant\SimpleFM\Loader\AbstractLoader::throwErrors
+     * @covers Soliant\SimpleFM\StringUtils::extractErrorFromPhpMessage
      */
     public function testLoad()
     {

--- a/tests/SoliantTest/SimpleFM/Loader/MockTest.php
+++ b/tests/SoliantTest/SimpleFM/Loader/MockTest.php
@@ -53,6 +53,8 @@ class MockTest extends \PHPUnit_Framework_TestCase
      * @covers Soliant\SimpleFM\Loader\Mock::load
      * @covers Soliant\SimpleFM\Loader\Mock::setTestXml
      * @covers Soliant\SimpleFM\Loader\AbstractLoader::handleReturn
+     * @covers Soliant\SimpleFM\Loader\AbstractLoader::errorCapture
+     * @covers Soliant\SimpleFM\Loader\AbstractLoader::hasError
      */
     public function testLoad()
     {


### PR DESCRIPTION
Refactor Loader and Adapter so that Loader can return its own error result. This allows more informative error messages, for example, in the event of cURL errors. Minor housekeeping.