### PR TITLE
Bugfix. Typesafe modid

### DIFF
--- a/library/Soliant/SimpleFM/Version.php
+++ b/library/Soliant/SimpleFM/Version.php
@@ -11,5 +11,5 @@ namespace Soliant\SimpleFM;
 
 final class Version
 {
-    const VERSION = '2.0.4';
+    const VERSION = '2.0.5';
 }

--- a/library/Soliant/SimpleFM/ZF2/Entity/AbstractEntity.php
+++ b/library/Soliant/SimpleFM/ZF2/Entity/AbstractEntity.php
@@ -281,14 +281,14 @@ abstract class AbstractEntity implements ArraySerializableInterface
         $getterName = 'get' . ucfirst($propertyName);
 
         if ($getterName == 'getRecid') {
-            $value = $this->getRecid();
-            if (!empty($value)) {
-                $this->simpleFMAdapterRow['-recid'] = $value;
+            $recid = $this->getRecid();
+            if ($recid !== '' && $recid !== null) {
+                $this->simpleFMAdapterRow['-recid'] = $recid;
             }
         } elseif ($getterName == 'getModid') {
             $recid = $this->getRecid();
             $modid = $this->getModid();
-            if (!empty($modid) && !empty($recid)) {
+            if ($modid !== '' && $recid !== '' && $modid !== null && $recid !== null) {
                 $this->simpleFMAdapterRow['-modid'] = $modid;
             }
         } else {


### PR DESCRIPTION
The default modid value is `0` so using `empty` function means it often fails to match as expected.