### PR TITLE
Update to support latest ZF2 and ZF3 versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,15 @@
     ],
     "require": {
         "php": "^5.5 || ^7.0",
-        "doctrine/common": "^2.2.0"
+        "doctrine/common": "^2.2.0",
+        "zendframework/zend-form": "^2.9",
+        "zendframework/zend-authentication": "^2.5",
+        "zendframework/zend-crypt": "^3.1",
+        "zendframework/zend-servicemanager": "^3.1",
+        "zendframework/zend-hydrator": "^2.2",
+        "zendframework/zend-session": "^2.7"
     },
     "require-dev": {
-        "zendframework/zendframework": "^2.5",
         "phpunit/PHPUnit": "^4.7",
         "phpunit/phpunit-skeleton-generator": "^2.0",
         "mockery/mockery": "^0.9.4",
@@ -25,7 +30,7 @@
     },
     "suggest": {
         "zendframework/zendframework": "Required if you plan on using SimpleFM/ZF2 components.",
-        "ext-mcrypt": "Required for SimpleFM/ZF2/Authentication if you plan on enabling password retrieval."
+        "ext-openssl": "Required for SimpleFM/ZF2/Authentication if you plan on enabling password retrieval."
     },
     "autoload": {
         "psr-0": {

--- a/library/Soliant/SimpleFM/ZF2/AdapterServiceFactory.php
+++ b/library/Soliant/SimpleFM/ZF2/AdapterServiceFactory.php
@@ -9,21 +9,14 @@
 
 namespace Soliant\SimpleFM\ZF2;
 
+use Interop\Container\ContainerInterface;
 use Soliant\SimpleFM\Adapter;
 use Soliant\SimpleFM\Exception\InvalidArgumentException;
 use Soliant\SimpleFM\HostConnection;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
 
-class AdapterServiceFactory implements FactoryInterface
+class AdapterServiceFactory
 {
-    /**
-     * Create db adapter service
-     *
-     * @param ServiceLocatorInterface $serviceLocator
-     * @return Adapter
-     */
-    public function createService(ServiceLocatorInterface $sm)
+    public function __invoke(ContainerInterface $sm)
     {
         $config = $sm->get('config');
 

--- a/library/Soliant/SimpleFM/ZF2/Authentication/Mapper/Identity.php
+++ b/library/Soliant/SimpleFM/ZF2/Authentication/Mapper/Identity.php
@@ -13,7 +13,7 @@ use Zend\Crypt\BlockCipher;
 use Zend\Form\Annotation;
 
 /**
- * @Annotation\Hydrator("Zend\Stdlib\Hydrator\ObjectProperty")
+ * @Annotation\Hydrator("Zend\Hydrator\ObjectProperty")
  * @Annotation\Name("login_form")
  */
 class Identity
@@ -163,7 +163,7 @@ class Identity
             return null;
         }
 
-        $blockCipher = BlockCipher::factory('mcrypt', ['algo' => 'aes']);
+        $blockCipher = BlockCipher::factory('openssl', ['algo' => 'aes']);
         $blockCipher->setKey($encryptionKey);
         return $blockCipher->decrypt($this->password);
     }
@@ -186,7 +186,7 @@ class Identity
             throw new Exception\InvalidArgumentException('The encryptionKey must not be empty');
         }
 
-        $blockCipher = BlockCipher::factory('mcrypt', ['algo' => 'aes']);
+        $blockCipher = BlockCipher::factory('openssl', ['algo' => 'aes']);
         $blockCipher->setKey($encryptionKey);
         $this->password = $blockCipher->encrypt($password);
 

--- a/tests/SoliantTest/SimpleFM/ZF2/AdapterServiceFactoryTest.php
+++ b/tests/SoliantTest/SimpleFM/ZF2/AdapterServiceFactoryTest.php
@@ -141,13 +141,13 @@ class AdapterServiceFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayNotHasKey('sslVerifyPeer', $this->serviceManager2->get('config')['simple_fm_host_params']);
         $this->assertArrayNotHasKey('hostName', $this->serviceManager3->get('config')['simple_fm_host_params']);
 
-        $adapter = $this->object->createService($this->serviceManager1);
+        $adapter = $this->object->__invoke($this->serviceManager1);
         $this->assertInstanceOf(Adapter::class, $adapter);
 
-        $adapter = $this->object->createService($this->serviceManager2);
+        $adapter = $this->object->__invoke($this->serviceManager2);
         $this->assertInstanceOf(Adapter::class, $adapter);
 
         $this->setExpectedException(InvalidArgumentException::class);
-        $adapter = $this->object->createService($this->serviceManager3);
+        $adapter = $this->object->__invoke($this->serviceManager3);
     }
 }

--- a/tests/SoliantTest/SimpleFM/ZF2/Authentication/Mapper/IdentityTest.php
+++ b/tests/SoliantTest/SimpleFM/ZF2/Authentication/Mapper/IdentityTest.php
@@ -96,7 +96,7 @@ class IdentityTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Soliant\SimpleFM\ZF2\Authentication\Mapper\Identity::setPassword
      * @covers Soliant\SimpleFM\ZF2\Authentication\Mapper\Identity::getPassword
-     * Requires ext-mcrypt (PHP extension)
+     * Requires ext-openssl PHP extension)
      */
     public function testSetAndGetPasswordGood()
     {


### PR DESCRIPTION
- Removed excessive use zendframework/zendframework composer dependency and exchanged it against individual ones.
- Exchanged ext-mcrypt against ext-openssl.
- Updated factory to use new ContainerInterop
- Updated Identity mapper to use new Zend\Hydrator package