### PR TITLE
Add new UnknownFieldException

### DIFF
--- a/src/Client/ResultSet/Exception/UnknownFieldException.php
+++ b/src/Client/ResultSet/Exception/UnknownFieldException.php
@@ -6,11 +6,14 @@ namespace Soliant\SimpleFM\Client\ResultSet\Exception;
 use DomainException;
 use Exception;
 
-final class ParseException extends DomainException implements ExceptionInterface
+final class UnknownFieldException extends DomainException implements ExceptionInterface
 {
-    public static function fromInvalidFieldType(string $name, string $type) : self
+    public static function fromUnknownField()
     {
-        return new self(sprintf('Invalid field type "%s" for field "%s" discovered', $type, $name));
+        return new self(
+            'A field definition result is "unknown". This is normally due to a field on the layout having being '
+            . 'deleted from the table or the authenticating user not having permission to view it.'
+        );
     }
 
     public static function fromConcreteException(
@@ -20,7 +23,7 @@ final class ParseException extends DomainException implements ExceptionInterface
         Exception $previousException
     ) : self {
         return new self(sprintf(
-            'Could not parse response from database "%s" with table "%s" and layout "%s". Reason: %s',
+            'Unknown field in database "%s" with table "%s" and layout "%s". Reason: %s',
             $database,
             $table,
             $layout,

--- a/test/Client/ResultSet/ResultSetClientTest.php
+++ b/test/Client/ResultSet/ResultSetClientTest.php
@@ -9,6 +9,7 @@ use Litipk\BigNumbers\Decimal;
 use PHPUnit_Framework_TestCase as TestCase;
 use Soliant\SimpleFM\Client\Exception\FileMakerException;
 use Soliant\SimpleFM\Client\ResultSet\Exception\ParseException;
+use Soliant\SimpleFM\Client\ResultSet\Exception\UnknownFieldException;
 use Soliant\SimpleFM\Client\ResultSet\ResultSetClient;
 use Soliant\SimpleFM\Client\ResultSet\Transformer\StreamProxy;
 use Soliant\SimpleFM\Connection\Command;
@@ -213,7 +214,7 @@ final class ResultSetClientTest extends TestCase
                                 'Repeating Field' => [
                                     null,
                                     Decimal::fromInteger(0),
-                                    null
+                                    null,
                                 ],
                             ],
                             [
@@ -376,7 +377,8 @@ final class ResultSetClientTest extends TestCase
     public function testInvalidFieldTransformerTypeFake()
     {
         $this->expectException(ParseException::class);
-        $this->expectExceptionMessage('Invalid field type "fake" for field "id" discovered');
+        $this->expectExceptionMessage('Could not parse response from database "XmlSchemaDemo" with table "Parent" and '
+            . 'layout "Parent". Reason: Invalid field type "fake" for field "id" discovered');
 
         $command = new Command('foo', []);
         $client = $this->createClient($command, 'invalidFieldTypeFake.xml');
@@ -419,11 +421,13 @@ final class ResultSetClientTest extends TestCase
         $client->execute($command);
     }
 
-    public function testDeletedField()
+    public function testUnknownField()
     {
-        $this->expectException(ParseException::class);
+        $this->expectException(UnknownFieldException::class);
         $this->expectExceptionMessage(
-            'A field has been deleted from the table, but remained in the layout'
+            'Unknown field in database "XmlSchemaDemo" with table "Child" and layout "Child". Reason: '
+            . 'A field definition result is "unknown". This is normally due to a field on the layout having being '
+            . 'deleted from the table or the authenticating user not having permission to view it.'
         );
 
         $command = new Command('foo', []);


### PR DESCRIPTION
@lavere and I tracked down an error he was seeing with unknown field. It wasn't an error per se, because what was happening is the login request, which is made with the  authenticating user's credentials instead of the system credentials, only had privilege to see the WebUser entity, but he was using a layout that had a Person association. In this case, the XML result is identical to the case where the field has been deleted from the table, but not from the layout. So what we've done is create a better exception message (suggesting both possibilities), and also created a distinct Exception type. This isn't exactly a parse error. It's expected behavior from FileMaker. We could think of use cases where we'd want to handle this exception gracefully and differently from other types of parse errors.